### PR TITLE
Update sync tasks to return up to 200 results; add date restriction t…

### DIFF
--- a/katello-publish-cvs.py
+++ b/katello-publish-cvs.py
@@ -26,7 +26,7 @@ ORG_NAME = "Default Organization"
 ENVIRONMENTS = {}
 # Search string to list currently running publish tasks
 publish_tasks = "foreman_tasks/api/tasks?search=utf8=%E2%9C%93&search=label+%3D+Actions%3A%3AKatello%3A%3AContentView%3A%3APublish+and+state+%3D+running"
-sync_tasks = "foreman_tasks/api/tasks?utf8=%E2%9C%93&search=label+%3D+Actions%3A%3AKatello%3A%3ARepository%3A%3ASync+and+state+%3D+stopped+and+result+%3D+success"
+sync_tasks = "foreman_tasks/api/tasks?utf8=%E2%9C%93&per_page=1000&search=label+%3D+Actions%3A%3AKatello%3A%3ARepository%3A%3ASync+and+state+%3D+stopped+and+result+%3D+success"
 
 def get_json(location):
     """


### PR DESCRIPTION
Update sync tasks to return up to 200 results; add date restriction to return more recent results.

* By default, API returns a page of 20 results. If there are more than 20 sync tasks since the last run, this introduces missed tasks.  Add per_page=200 to API call to ureturn up to 200 results.  Potential for same problem if more than 200 sync tasks have completed since the last run of the script.
* Add started_at > "8 days ago" to search string to limit results to the past 8 days (assuming script is run at least weekly). Potential for problems if script is run more than 8 days apart.