### PR TITLE
Allow user to specify a specific CV to update and set parameters on configuration file

### DIFF
--- a/katello-publish-cvs.ini
+++ b/katello-publish-cvs.ini
@@ -1,0 +1,5 @@
+[katello]
+username = admin
+password = adminpassword
+org_name = MyCompany
+url = https://satellite001.intranet.company.com/

--- a/katello-publish-cvs.py
+++ b/katello-publish-cvs.py
@@ -151,9 +151,10 @@ def main():
     
     # Get all non-composite CVs from the API
     if cv_name == 'ALL':
-        cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true&name={}".format(SAT_API, org_id, cv_name))
-    else:
         cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true".format(SAT_API, org_id))
+    else:
+        cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true&name={}".format(SAT_API, org_id, cv_name))
+
    
     # Get all sync tasks
     sync_tasks_json = get_json(URL + sync_tasks)

--- a/katello-publish-cvs.py
+++ b/katello-publish-cvs.py
@@ -5,19 +5,23 @@ import sys
 import time
 from datetime import datetime
 import requests
+import argparse
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+import logging
+import ConfigParser as configparser
+import os
 
 # URL to your Satellite 6 server
 URL = "https://localhost/"
 # URL for the API to your deployed Satellite 6 server
-SAT_API = URL + "katello/api/v2/"
+#SAT_API = URL + "katello/api/v2/"
 # Katello-specific API
-KATELLO_API = URL + "katello/api/"
+#KATELLO_API = URL + "katello/api/"
 POST_HEADERS = {'content-type': 'application/json'}
 # Default credentials to login to Satellite 6
 USERNAME = "admin"
-PASSWORD = "changeme"
+PASSWORD = "admin"
 # Ignore SSL for now
 SSL_VERIFY = False
 # Name of the organization to be either created or used
@@ -32,8 +36,11 @@ def get_json(location):
     """
     Performs a GET using the passed URL location
     """
-
-    r = requests.get(location, auth=(USERNAME, PASSWORD), verify=SSL_VERIFY)
+    try:
+        r = requests.get(location, auth=(USERNAME, PASSWORD), verify=SSL_VERIFY)
+    except Exception as e:
+        log.critical(str(e))
+        sys.exit(1)
 
     return r.json()
 
@@ -42,12 +49,15 @@ def post_json(location, json_data):
     """
     Performs a POST and passes the data to the URL location
     """
-
-    result = requests.post(location,
+    try:
+        result = requests.post(location,
                             data=json_data,
                             auth=(USERNAME, PASSWORD),
                             verify=SSL_VERIFY,
                             headers=POST_HEADERS)
+    except Exception as e:
+        log.critical(str(e))
+        sys.exit(1)
 
     return result.json()
 
@@ -55,12 +65,15 @@ def put_json(location, json_data):
     """
     Performs a PUT and passes the data to the URL location
     """
-
-    result = requests.put(location,
+    try:
+        result = requests.put(location,
                             data=json_data,
                             auth=(USERNAME, PASSWORD),
                             verify=SSL_VERIFY,
                             headers=POST_HEADERS)
+    except Exception as e:
+        log.critical(str(e))
+        sys.exit(1)
 
     return result.json()
 
@@ -84,33 +97,66 @@ def wait_for_publish(seconds):
     
 def main():
 
-    # Check that organization exists and extract its ID
-    org_json = get_json(SAT_API + "organizations/" + ORG_NAME)
+    parser = argparse.ArgumentParser(description="Push new repositories to clients for given product")
+    parser.add_argument("--cv-name", help="name of the content view containing the updated repository", required=True)
+    parser.add_argument("-v", help="Debug logging", action='store_true')
+    parser.add_argument("-c", "--config", help="Config File with katello addr and credentials", default="~/.config/katello-publish-cvs.ini")
+    args = parser.parse_args()
+    cv_name = args.cv_name
     
+    # enable logging
+    global log, URL, PASSWORD, ORG_NAME, SAT_API, KATELLO_API
+    log = logging.getLogger(__name__)
+    out_hdlr = logging.StreamHandler(sys.stdout)
+    out_hdlr.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
+    out_hdlr.setLevel(logging.DEBUG)
+    log.addHandler(out_hdlr)
+    if args.v:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
+        
+    # Parsing Configuration and setting some defaults
+    config = configparser.ConfigParser()
+    config.read(os.path.expanduser(args.config))
+    sections = config.sections()
+    if len(sections) == 1:
+        URL = config.get(sections[0], 'url')
+        USERNAME = config.get(sections[0], 'username')
+        PASSWORD = config.get(sections[0], 'password')
+        ORG_NAME = config.get(sections[0], 'org_name')
+
+    SAT_API = URL + "katello/api/v2/"
+    KATELLO_API = URL + "katello/api/"
+        
+    # Check that organization exists and extract its ID
+    org_json = get_json("{}organizations/{}".format(SAT_API, ORG_NAME))
     if org_json.get('error', None):
-        print "ERROR: Inspect message"
-        print org_json
+        log.error("ERROR: Inspect message")
+        log.error(org_json)
         sys.exit(1)
 
-    org_id =org_json["id"]
-    print 'Organization \"' + ORG_NAME + ' has ID: ' + str(org_id)
+    org_id = org_json["id"]
+    log.debug('Organization "{}" has ID: {}'.format(ORG_NAME, org_id))
 
     # Fill dictionary of Lifecycle Environments as {name : id}
-    envs_json = get_json(KATELLO_API + "organizations/" + str(org_id) + "/environments?per_page=999")
+    envs_json = get_json("{}organizations/{}/environments?per_page=999".format(KATELLO_API, org_id))
     for env in envs_json["results"]:
         ENVIRONMENTS[env["name"]] = env["id"]
 
-    print "Lifecycle environments: " + str(ENVIRONMENTS)
+    log.debug("Lifecycle environments: {}".format(ENVIRONMENTS))
     
     # Get all non-composite CVs from the API
-    cvs_json = get_json(SAT_API + "organizations/" + str(org_id) + "/content_views?noncomposite=true&nondefault=true")
+    cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true&name={}".format(SAT_API, org_id, cv_name))
    
     # Get all sync tasks
     sync_tasks_json = get_json(URL + sync_tasks)
 
     # Publish new versions of the CVs that have new content in the underlying repos
     published_cv_ids = []
+    searched_cv_ids = []
     for cv in cvs_json["results"]:
+        searched_cv_ids.append(cv["id"])
         last_published = cv["last_published"]
         if last_published is None:
             last_published = "2000-01-01 00:00:00 UTC"
@@ -118,54 +164,55 @@ def main():
 
         need_publish = False
         for repo in cv["repositories"]:
-
             for task in sync_tasks_json["results"]:
                 if task["input"]["repository"]["id"] == repo["id"]:
                     ended_at = datetime.strptime(task["ended_at"], '%Y-%m-%dT%H:%M:%S.000Z')
 
                     if ended_at > last_published and task["input"]["contents_changed"]:
-                        print "A sync task for repo \"" + repo["name"] + "\" downloaded new content and ended after " + cv["name"] + " was published last time"
+                        log.info("A sync task for repo \"{}\" downloaded new content and ended after {} was published last time".format(repo['name'], cv['name']))
                         need_publish = True
 
         if need_publish:
-            print "Publish " + cv["name"] + " because some of its content has changed"
-            post_json(KATELLO_API + "content_views/" + str(cv["id"]) + "/publish", json.dumps({"description": "Automatic publish over API"}))
+            log.info("Publish {} because some of its content has changed".format(cv["name"]))
+            post_json("{}content_views/{}/publish".format(KATELLO_API, cv['id']), json.dumps({"description": "Automatic publish over API"}))
             published_cv_ids.append(cv["id"])
         else:
-            print cv["name"] + " doesn't need to be published"
-
+            log.debug("{} doesn't need to be published".format(cv['name']))
+            
     wait_for_publish(10)
 
     # Get all CCVs from the API 
-    ccvs_json = get_json(SAT_API + "organizations/" + str(org_id) + "/content_views?composite=true")
+    ccvs_json = get_json("{}organizations/{}/content_views?composite=true".format(SAT_API, org_id))
     
     # Publish a new version of all CCs that contain any of the published CVs
     ccv_ids_to_promote = []
     for ccv in ccvs_json["results"]:
         new_component_ids = []
-        
+        skip = True
         for component in ccv["components"]:
-            cv_json = get_json(KATELLO_API + "content_views/" + str(component["content_view"]["id"]))
-            
+            if component["content_view_id"] in searched_cv_ids:
+                skip = False
+            cv_json = get_json("{}content_views/{}".format(KATELLO_API,component["content_view"]["id"]))
             for version in cv_json["versions"]:
                 if ENVIRONMENTS["Library"] in version["environment_ids"]:
                     new_component_ids.append(version["id"])
-        
-        print "Update " + ccv["name"] + " with new compontent IDs: " + str(new_component_ids)
+        if skip:
+            continue            
+        print "Update " + ccv["name"] + " with new component IDs: " + str(new_component_ids)
         put_json(KATELLO_API + "content_views/" + str(ccv["id"]), json.dumps({"component_ids": new_component_ids}))
         
         print "Publish new version of " + ccv["name"]
         post_json(KATELLO_API + "content_views/" + str(ccv["id"]) + "/publish", json.dumps({"description": "Automatic publish over API"}))
 
         # Get the ID of the version in Library 
-        version_in_library_id = get_json(KATELLO_API + "content_views/" + str(ccv["id"]) + "/content_view_versions?environment_id=" + str(ENVIRONMENTS["Library"]))["results"][0]["id"]
+        version_in_library_id = get_json("{}content_views/{}/content_view_versions?environment_id={}".format(KATELLO_API, ccv['id'], ENVIRONMENTS["Library"]))["results"][0]["id"]
         ccv_ids_to_promote.append(str(version_in_library_id))
 
     wait_for_publish(10)
     
-    print "Promote all effected CCVs to TEST environment"
+    print "Promote all effected CCVs to Sviluppo environment"
     for ccv_id in ccv_ids_to_promote:
-        post_json(KATELLO_API + "content_view_versions/" + str(ccv_id) + "/promote", json.dumps({"environment_id": ENVIRONMENTS["TEST"]})) 
+        post_json(KATELLO_API + "content_view_versions/" + str(ccv_id) + "/promote", json.dumps({"environment_id": ENVIRONMENTS["Sviluppo"]}))
 
 
 if __name__ == "__main__":

--- a/katello-publish-cvs.py
+++ b/katello-publish-cvs.py
@@ -102,6 +102,7 @@ def main():
                         help="name of the content view containing the repository that has been updated. Specify ALL if you want to update all the CVs", 
                         required=True)
     parser.add_argument("-v", help="Debug logging", action='store_true')
+    parser.add_argument("--target-env", help="Target Environment name for CCVs", default="Development")
     parser.add_argument("-c", "--config", help="Config File with katello addr and credentials", default="~/.config/katello-publish-cvs.ini")
     args = parser.parse_args()
     cv_name = args.cv_name
@@ -215,9 +216,9 @@ def main():
 
     wait_for_publish(10)
     
-    print "Promote all effected CCVs to Sviluppo environment"
+    print "Promote all effected CCVs to given environment"
     for ccv_id in ccv_ids_to_promote:
-        post_json(KATELLO_API + "content_view_versions/" + str(ccv_id) + "/promote", json.dumps({"environment_id": ENVIRONMENTS["Sviluppo"]}))
+        post_json(KATELLO_API + "content_view_versions/" + str(ccv_id) + "/promote", json.dumps({"environment_id": ENVIRONMENTS[args.target_env]}))
 
 
 if __name__ == "__main__":

--- a/katello-publish-cvs.py
+++ b/katello-publish-cvs.py
@@ -98,7 +98,9 @@ def wait_for_publish(seconds):
 def main():
 
     parser = argparse.ArgumentParser(description="Push new repositories to clients for given product")
-    parser.add_argument("--cv-name", help="name of the content view containing the updated repository", required=True)
+    parser.add_argument("--cv-name", 
+                        help="name of the content view containing the repository that has been updated. Specify ALL if you want to update all the CVs", 
+                        required=True)
     parser.add_argument("-v", help="Debug logging", action='store_true')
     parser.add_argument("-c", "--config", help="Config File with katello addr and credentials", default="~/.config/katello-publish-cvs.ini")
     args = parser.parse_args()
@@ -147,7 +149,10 @@ def main():
     log.debug("Lifecycle environments: {}".format(ENVIRONMENTS))
     
     # Get all non-composite CVs from the API
-    cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true&name={}".format(SAT_API, org_id, cv_name))
+    if cv_name == 'ALL':
+        cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true&name={}".format(SAT_API, org_id, cv_name))
+    else:
+        cvs_json = get_json("{}organizations/{}/content_views?noncomposite=true&nondefault=true".format(SAT_API, org_id))
    
     # Get all sync tasks
     sync_tasks_json = get_json(URL + sync_tasks)


### PR DESCRIPTION
This change is to introduce the ability to update a single CV (and all the connected CCVs) instead of all the CVs available. 

Quick changelog:
- Some python refactoring
- Introduction of logging and different logging levels (info/debug)
- Support for parameters (url, credentials) from configuration file
- CLI argument for specifying the single CV to update
- CLI argument for setting target promotion environment
- Some error management and logging